### PR TITLE
fix: recover stringified array values in formatKeyframeValue

### DIFF
--- a/src/ae-integration/generators/helpers.ts
+++ b/src/ae-integration/generators/helpers.ts
@@ -298,6 +298,21 @@ export function formatKeyframeValue(value: number | number[] | string): string {
   } else if (Array.isArray(value)) {
     return arrayToES3(value);
   } else if (typeof value === 'string') {
+    // Some MCP transports stringify untyped array arguments (e.g. "[100, 100]")
+    // because the set_keyframe `value` param has no declared JSON Schema type.
+    // Recover the array so multi-dimensional keyframes (Scale, Position) work
+    // instead of being quoted as a string and rejected by AE ("not an array").
+    const trimmed = value.trim();
+    if (trimmed.charAt(0) === '[' && trimmed.charAt(trimmed.length - 1) === ']') {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return arrayToES3(parsed);
+        }
+      } catch (e) {
+        // Not valid JSON — fall through and treat as a literal string value.
+      }
+    }
     return '"' + escapeString(value) + '"';
   }
   throw new Error('Invalid keyframe value type');


### PR DESCRIPTION
## Problem

`set_keyframe`'s `value` parameter is declared without a JSON Schema type. Some MCP transports therefore serialize array arguments to strings before they reach the server — e.g. `[100, 100]` arrives as the string `"[100, 100]"`.

`formatKeyframeValue` then treats that as a literal string and quotes it, so the generated ExtendScript hands After Effects a quoted string. AE rejects it with **"value is not an array"**, which makes Scale / Position (any multi-dimensional) keyframes impossible via `set_keyframe`. Scalar properties such as Opacity are unaffected.

## Fix

`src/ae-integration/generators/helpers.ts` — `formatKeyframeValue` now detects JSON-array-shaped strings (starts with `[`, ends with `]`), `JSON.parse`s them, and emits an ES3 array literal through the existing `arrayToES3`. Anything that is not a valid JSON array falls through and is still treated as a literal string.

- numbers → unchanged
- real arrays → unchanged
- genuine string values → unchanged (only `[...]`-shaped strings are reparsed)

Single commit, one file changed.

## Testing

Verified live in **After Effects 2026 (26.2.1)** through the MCP `set_keyframe` tool: `scale` keyframes with array values (`[50,50]` → `[100,100]`) now apply successfully, whereas the same call previously failed with "value is not an array". Scalar (Opacity) keyframes continue to work as before.