### PR TITLE
Fix set_keyframe array values and get_expression crash; add render_frame and get_comp_report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "ae-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^20.10.0",
+        "@types/node": "^20.19.43",
+        "tsx": "^4.23.1",
         "typescript": "^5.3.0"
       },
       "engines": {
@@ -42,6 +43,448 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -106,9 +549,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -443,6 +886,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -484,7 +969,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -609,6 +1093,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1301,6 +1800,25 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1422,7 +1940,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "jest",
+    "test": "tsx --test src/**/*.test.ts",
     "lint": "eslint src/**/*.ts",
     "clean": "rm -rf dist",
     "prepare": "npm run build"
@@ -31,7 +31,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
+    "@types/node": "^20.19.43",
+    "tsx": "^4.23.1",
     "typescript": "^5.3.0"
   },
   "engines": {

--- a/src/ae-integration/generators/compositionGenerators.ts
+++ b/src/ae-integration/generators/compositionGenerators.ts
@@ -249,3 +249,226 @@ export function generateSetActiveComposition(params: {
 
   return script;
 }
+
+
+/**
+ * Generate script to render a single frame of a composition to PNG.
+ * Gives the AI "eyes": the returned path can be read back by the assistant.
+ * Uses CompItem.saveFrameToPng (undocumented but stable since CC2020).
+ */
+export function generateRenderFrame(params: {
+  compId?: number;
+  compName?: string;
+  time: number;
+  outputDir?: string;
+  fileName?: string;
+}): string {
+  let script = '';
+  script += generateProjectCheck();
+  script += generateCompAccess(params.compId, params.compName);
+
+  const outputDir = params.outputDir || '~/Desktop/ae_probe';
+
+  script += 'var t = ' + params.time + ';\n';
+  script += 'if (t < 0) { t = 0; }\n';
+  script += 'if (t > comp.duration) { t = comp.duration; }\n';
+  script += 'var outFolder = new Folder("' + escapeString(outputDir) + '");\n';
+  script += 'if (!outFolder.exists) { outFolder.create(); }\n';
+  if (params.fileName) {
+    script += 'var outName = "' + escapeString(params.fileName) + '";\n';
+  } else {
+    script += 'var safeName = String(comp.name).replace(/[^A-Za-z0-9_\\-]+/g, "_");\n';
+    script += 'var outName = safeName + "_t" + String(Math.round(t * 100) / 100).replace(".", "_") + "s.png";\n';
+  }
+  script += 'var outFile = new File(outFolder.fsName + "/" + outName);\n';
+  script += 'if (!comp.saveFrameToPng) {\n';
+  script += '  throw new Error("saveFrameToPng is not available in this After Effects version");\n';
+  script += '}\n';
+  script += 'comp.saveFrameToPng(t, outFile);\n';
+
+  script += generateResultObject({
+    success: 'true',
+    time: 't',
+    path: 'outFile.fsName'
+  });
+
+  return script;
+}
+
+/**
+ * Generate script for a full composition report: layers with geometry,
+ * text data, expressions, keyframes and time samples. Lets the AI verify
+ * the real state of a comp instead of trusting its own writes.
+ */
+export function generateGetCompReport(params: {
+  compId?: number;
+  compName?: string;
+  sampleTimes?: number[];
+  textPreview?: number;
+}): string {
+  let script = '';
+  script += generateProjectCheck();
+  script += generateCompAccess(params.compId, params.compName);
+
+  const preview = params.textPreview || 120;
+
+  // -- helpers (ES3) --
+  script += 'function __r2(v) { return Math.round(v * 100) / 100; }\n';
+  script += 'function __vec(v) {\n';
+  script += '  if (v === null || v === undefined) { return null; }\n';
+  script += '  if (v instanceof Array) {\n';
+  script += '    var o = [];\n';
+  script += '    for (var i = 0; i < v.length; i++) { o.push(__r2(v[i])); }\n';
+  script += '    return o;\n';
+  script += '  }\n';
+  script += '  return __r2(v);\n';
+  script += '}\n';
+
+  // -- comp info --
+  script += 'var report = {};\n';
+  script += 'report.comp = { id: comp.id, name: comp.name, width: comp.width, height: comp.height, duration: __r2(comp.duration), frameRate: __r2(comp.frameRate), numLayers: comp.numLayers };\n';
+
+  // -- markers --
+  script += 'report.markers = [];\n';
+  script += 'try {\n';
+  script += '  var mk = comp.markerProperty;\n';
+  script += '  for (var mi = 1; mi <= mk.numKeys; mi++) {\n';
+  script += '    report.markers.push({ time: __r2(mk.keyTime(mi)), comment: mk.keyValue(mi).comment });\n';
+  script += '  }\n';
+  script += '} catch (eMk) {}\n';
+
+  // -- sample times: explicit > markers > uniform 5 --
+  if (params.sampleTimes && params.sampleTimes.length > 0) {
+    const times: string[] = [];
+    for (let i = 0; i < params.sampleTimes.length; i++) {
+      times.push(String(params.sampleTimes[i]));
+    }
+    script += 'var sampleTimes = [' + times.join(', ') + '];\n';
+  } else {
+    script += 'var sampleTimes = [];\n';
+    script += 'for (var si = 0; si < report.markers.length && si < 12; si++) { sampleTimes.push(report.markers[si].time); }\n';
+    script += 'if (sampleTimes.length === 0) {\n';
+    script += '  for (var ui = 1; ui <= 5; ui++) { sampleTimes.push(__r2(comp.duration * ui / 6)); }\n';
+    script += '}\n';
+  }
+  script += 'report.sampleTimes = sampleTimes;\n';
+
+  // -- recursive walk for expressions + keyframes --
+  script += 'function __walk(group, path, acc, depth) {\n';
+  script += '  if (depth > 5) { return; }\n';
+  script += '  var n = 0;\n';
+  script += '  try { n = group.numProperties; } catch (eN) { return; }\n';
+  script += '  for (var i = 1; i <= n; i++) {\n';
+  script += '    var sub = null;\n';
+  script += '    try { sub = group.property(i); } catch (eS) { continue; }\n';
+  script += '    if (!sub) { continue; }\n';
+  script += '    var here = path + "/" + sub.name;\n';
+  script += '    if (sub.propertyType === PropertyType.PROPERTY) {\n';
+  script += '      var entry = null;\n';
+  script += '      try {\n';
+  script += '        if (sub.canSetExpression && sub.expression !== "") {\n';
+  script += '          entry = { path: here, expression: sub.expression, enabled: sub.expressionEnabled };\n';
+  script += '          if (sub.expressionError) { entry.error = sub.expressionError; }\n';
+  script += '        }\n';
+  script += '      } catch (eE) {}\n';
+  script += '      try {\n';
+  script += '        if (sub.numKeys > 0) {\n';
+  script += '          if (!entry) { entry = { path: here }; }\n';
+  script += '          entry.numKeys = sub.numKeys;\n';
+  script += '          entry.keys = [];\n';
+  script += '          for (var k = 1; k <= sub.numKeys && k <= 10; k++) {\n';
+  script += '            entry.keys.push({ t: __r2(sub.keyTime(k)), v: __vec(sub.keyValue(k)) });\n';
+  script += '          }\n';
+  script += '        }\n';
+  script += '      } catch (eK) {}\n';
+  script += '      if (entry) { acc.push(entry); }\n';
+  script += '    } else {\n';
+  script += '      __walk(sub, here, acc, depth + 1);\n';
+  script += '    }\n';
+  script += '  }\n';
+  script += '}\n';
+
+  // -- layers --
+  script += 'report.layers = [];\n';
+  script += 'for (var li = 1; li <= comp.numLayers; li++) {\n';
+  script += '  var ly = comp.layer(li);\n';
+  script += '  var L = { index: li, name: ly.name, matchName: ly.matchName, enabled: ly.enabled, inPoint: __r2(ly.inPoint), outPoint: __r2(ly.outPoint) };\n';
+  script += '  try { L.threeD = ly.threeDLayer; } catch (e3) {}\n';
+  script += '  try { L.parent = ly.parent ? ly.parent.name : null; } catch (eP) {}\n';
+  script += '  try {\n';
+  script += '    var rc = ly.sourceRectAtTime(ly.inPoint, false);\n';
+  script += '    L.rect = { w: Math.round(rc.width), h: Math.round(rc.height), left: Math.round(rc.left), top: Math.round(rc.top) };\n';
+  script += '  } catch (eR) {}\n';
+  script += '  try { L.position = __vec(ly.property("Position").value); } catch (ePos) {}\n';
+  script += '  try { L.anchor = __vec(ly.property("Anchor Point").value); } catch (eA) {}\n';
+  script += '  try { L.scale = __vec(ly.property("Scale").value); } catch (eSc) {}\n';
+  script += '  try { L.opacity = __r2(ly.property("Opacity").value); } catch (eO) {}\n';
+  script += '  try {\n';
+  script += '    if (ly.threeDLayer) {\n';
+  script += '      L.rotX = __r2(ly.property("X Rotation").value);\n';
+  script += '      L.rotY = __r2(ly.property("Y Rotation").value);\n';
+  script += '      L.rotZ = __r2(ly.property("Z Rotation").value);\n';
+  script += '    } else {\n';
+  script += '      L.rotation = __r2(ly.property("Rotation").value);\n';
+  script += '    }\n';
+  script += '  } catch (eRot) {}\n';
+  script += '  if (ly instanceof TextLayer) {\n';
+  script += '    try {\n';
+  script += '      var td = ly.property("Source Text").value;\n';
+  script += '      L.text = { font: td.font, fontFamily: td.fontFamily, fontSize: __r2(td.fontSize), tracking: __r2(td.tracking), preview: String(td.text).substring(0, ' + preview + ') };\n';
+  script += '      try { L.text.leading = __r2(td.leading); } catch (eLd) {}\n';
+  script += '    } catch (eT) {}\n';
+  script += '  }\n';
+  script += '  if (ly.matchName === "ADBE Camera Layer") {\n';
+  script += '    try { L.zoom = __r2(ly.property("Zoom").value); } catch (eZ) {}\n';
+  script += '  }\n';
+  script += '  var animated = [];\n';
+  script += '  __walk(ly, "", animated, 0);\n';
+  script += '  if (animated.length > 0) { L.animatedProps = animated; }\n';
+  script += '  var samples = [];\n';
+  script += '  for (var st = 0; st < sampleTimes.length; st++) {\n';
+  script += '    var T = sampleTimes[st];\n';
+  script += '    if (T < ly.inPoint || T > ly.outPoint) { continue; }\n';
+  script += '    try {\n';
+  script += '      var hasAnim = false;\n';
+  script += '      var pp = ly.property("Position");\n';
+  script += '      var op = ly.property("Opacity");\n';
+  script += '      var sp = ly.property("Scale");\n';
+  script += '      if (pp && (pp.numKeys > 0 || pp.expressionEnabled)) { hasAnim = true; }\n';
+  script += '      if (op && (op.numKeys > 0 || op.expressionEnabled)) { hasAnim = true; }\n';
+  script += '      if (sp && (sp.numKeys > 0 || sp.expressionEnabled)) { hasAnim = true; }\n';
+  script += '      if (hasAnim) {\n';
+  script += '        samples.push({ t: __r2(T), position: __vec(pp.valueAtTime(T, false)), scale: __vec(sp.valueAtTime(T, false)), opacity: __r2(op.valueAtTime(T, false)) });\n';
+  script += '      }\n';
+  script += '    } catch (eSm) {}\n';
+  script += '  }\n';
+  script += '  if (samples.length > 0) { L.samples = samples; }\n';
+  script += '  report.layers.push(L);\n';
+  script += '}\n';
+
+  // -- fonts used vs installed --
+  script += 'report.fonts = [];\n';
+  script += 'try {\n';
+  script += '  var used = {};\n';
+  script += '  for (var fi = 0; fi < report.layers.length; fi++) {\n';
+  script += '    var lt = report.layers[fi].text;\n';
+  script += '    if (lt && lt.font) { used[lt.font] = 1; }\n';
+  script += '  }\n';
+  script += '  for (var ps in used) {\n';
+  script += '    if (!used.hasOwnProperty(ps)) { continue; }\n';
+  script += '    var entryF = { postScriptName: ps, installed: "unknown" };\n';
+  script += '    try {\n';
+  script += '      var all = app.fonts.allFonts;\n';
+  script += '      entryF.installed = false;\n';
+  script += '      for (var ai = 0; ai < all.length; ai++) {\n';
+  script += '        if (all[ai].postScriptName === ps) { entryF.installed = true; break; }\n';
+  script += '      }\n';
+  script += '    } catch (eF) {}\n';
+  script += '    report.fonts.push(entryF);\n';
+  script += '  }\n';
+  script += '} catch (eFF) {}\n';
+
+  script += 'report;\n';
+
+  return script;
+}

--- a/src/ae-integration/generators/compositionGenerators.ts
+++ b/src/ae-integration/generators/compositionGenerators.ts
@@ -273,9 +273,18 @@ export function generateRenderFrame(params: {
   script += 'if (t < 0) { t = 0; }\n';
   script += 'if (t > comp.duration) { t = comp.duration; }\n';
   script += 'var outFolder = new Folder("' + escapeString(outputDir) + '");\n';
-  script += 'if (!outFolder.exists) { outFolder.create(); }\n';
+  script += 'if (!outFolder.exists) {\n';
+  script += '  if (!outFolder.create()) {\n';
+  script += '    throw new Error("Failed to create output folder: " + outFolder.fsName);\n';
+  script += '  }\n';
+  script += '}\n';
+  // Sanitize custom fileName to a basename with a safe charset so callers cannot
+  // escape outputDir via "../" or absolute paths. Default names are already safe.
   if (params.fileName) {
-    script += 'var outName = "' + escapeString(params.fileName) + '";\n';
+    const base = params.fileName.replace(/\\/g, '/').split('/').pop() || '';
+    const safe = base.replace(/[^A-Za-z0-9_\-.]+/g, '_').replace(/^\.+/, '');
+    const outName = safe || 'frame.png';
+    script += 'var outName = "' + escapeString(outName) + '";\n';
   } else {
     script += 'var safeName = String(comp.name).replace(/[^A-Za-z0-9_\\-]+/g, "_");\n';
     script += 'var outName = safeName + "_t" + String(Math.round(t * 100) / 100).replace(".", "_") + "s.png";\n';
@@ -285,6 +294,9 @@ export function generateRenderFrame(params: {
   script += '  throw new Error("saveFrameToPng is not available in this After Effects version");\n';
   script += '}\n';
   script += 'comp.saveFrameToPng(t, outFile);\n';
+  script += 'if (!outFile.exists) {\n';
+  script += '  throw new Error("Frame render did not produce a file: " + outFile.fsName);\n';
+  script += '}\n';
 
   script += generateResultObject({
     success: 'true',
@@ -313,15 +325,24 @@ export function generateGetCompReport(params: {
   const preview = params.textPreview || 120;
 
   // -- helpers (ES3) --
-  script += 'function __r2(v) { return Math.round(v * 100) / 100; }\n';
+  // Never emit NaN/Infinity: CEP JSON.stringify polyfills turn them into bare
+  // tokens that Node JSON.parse rejects, breaking the whole report bridge.
+  script += 'function __r2(v) {\n';
+  script += '  if (typeof v !== "number" || !isFinite(v)) { return null; }\n';
+  script += '  return Math.round(v * 100) / 100;\n';
+  script += '}\n';
   script += 'function __vec(v) {\n';
   script += '  if (v === null || v === undefined) { return null; }\n';
+  script += '  if (typeof v === "number") { return __r2(v); }\n';
   script += '  if (v instanceof Array) {\n';
   script += '    var o = [];\n';
-  script += '    for (var i = 0; i < v.length; i++) { o.push(__r2(v[i])); }\n';
+  script += '    for (var i = 0; i < v.length; i++) {\n';
+  script += '      if (typeof v[i] !== "number" || !isFinite(v[i])) { return null; }\n';
+  script += '      o.push(__r2(v[i]));\n';
+  script += '    }\n';
   script += '    return o;\n';
   script += '  }\n';
-  script += '  return __r2(v);\n';
+  script += '  return null;\n';
   script += '}\n';
 
   // -- comp info --
@@ -420,7 +441,7 @@ export function generateGetCompReport(params: {
   script += '    } catch (eT) {}\n';
   script += '  }\n';
   script += '  if (ly.matchName === "ADBE Camera Layer") {\n';
-  script += '    try { L.zoom = __r2(ly.property("Zoom").value); } catch (eZ) {}\n';
+  script += '    try { L.zoom = __r2(ly.property("Camera Options").property("Zoom").value); } catch (eZ) {}\n';
   script += '  }\n';
   script += '  var animated = [];\n';
   script += '  __walk(ly, "", animated, 0);\n';
@@ -458,10 +479,21 @@ export function generateGetCompReport(params: {
   script += '    if (!used.hasOwnProperty(ps)) { continue; }\n';
   script += '    var entryF = { postScriptName: ps, installed: "unknown" };\n';
   script += '    try {\n';
-  script += '      var all = app.fonts.allFonts;\n';
+  // AE 24+: allFonts is an array of family arrays; older shapes may be flat.
   script += '      entryF.installed = false;\n';
-  script += '      for (var ai = 0; ai < all.length; ai++) {\n';
-  script += '        if (all[ai].postScriptName === ps) { entryF.installed = true; break; }\n';
+  script += '      if (app.fonts && typeof app.fonts.getFontByPostScriptName === "function") {\n';
+  script += '        entryF.installed = !!app.fonts.getFontByPostScriptName(ps);\n';
+  script += '      } else {\n';
+  script += '        var all = app.fonts.allFonts;\n';
+  script += '        for (var ai = 0; ai < all.length; ai++) {\n';
+  script += '          var family = all[ai];\n';
+  script += '          if (family && family.postScriptName === ps) { entryF.installed = true; break; }\n';
+  script += '          if (!(family instanceof Array)) { continue; }\n';
+  script += '          for (var fi2 = 0; fi2 < family.length; fi2++) {\n';
+  script += '            if (family[fi2] && family[fi2].postScriptName === ps) { entryF.installed = true; break; }\n';
+  script += '          }\n';
+  script += '          if (entryF.installed) { break; }\n';
+  script += '        }\n';
   script += '      }\n';
   script += '    } catch (eF) {}\n';
   script += '    report.fonts.push(entryF);\n';

--- a/src/ae-integration/generators/expressionGenerators.ts
+++ b/src/ae-integration/generators/expressionGenerators.ts
@@ -246,12 +246,14 @@ export function generateGetExpression(params: {
   script += generateLayerAccess('comp', params.layerIndex, params.layerName);
   script += generatePropertyAccess('layer', params.property);
 
-  script += '{\n';
-  script += '  property: "' + escapeString(params.property) + '",\n';
-  script += '  expression: prop.expression,\n';
-  script += '  expressionEnabled: prop.expressionEnabled,\n';
-  script += '  expressionError: prop.expressionError || null\n';
-  script += '};\n';
+  // NOTE: a bare "{...};" at statement position is parsed by ExtendScript as a
+  // BLOCK (labels + SyntaxError), not an object literal. Assign to a var instead.
+  script += 'var result = {};\n';
+  script += 'result.property = "' + escapeString(params.property) + '";\n';
+  script += 'result.expression = prop.expression;\n';
+  script += 'result.expressionEnabled = prop.expressionEnabled;\n';
+  script += 'result.expressionError = prop.expressionError || null;\n';
+  script += 'result;\n';
 
   return script;
 }

--- a/src/ae-integration/generators/helpers.test.ts
+++ b/src/ae-integration/generators/helpers.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatKeyframeValue } from './helpers.js';
+
+describe('formatKeyframeValue', () => {
+  it('passes through numbers', () => {
+    assert.equal(formatKeyframeValue(50), '50');
+    assert.equal(formatKeyframeValue(-1.5), '-1.5');
+  });
+
+  it('passes through real arrays', () => {
+    assert.equal(formatKeyframeValue([100, 100]), '[100, 100]');
+    assert.equal(formatKeyframeValue([540, 960, 0]), '[540, 960, 0]');
+  });
+
+  it('recovers stringified numeric arrays from MCP transports', () => {
+    assert.equal(formatKeyframeValue('[100, 100]'), '[100, 100]');
+    assert.equal(formatKeyframeValue(' [50,50] '), '[50, 50]');
+    assert.equal(formatKeyframeValue('[1e-3, 2.5]'), '[0.001, 2.5]');
+  });
+
+  it('recovers stringified numbers', () => {
+    assert.equal(formatKeyframeValue('780'), '780');
+    assert.equal(formatKeyframeValue('-12.5'), '-12.5');
+  });
+
+  it('recovers stringified {x,y,z} objects', () => {
+    assert.equal(formatKeyframeValue('{"x":10,"y":20}'), '[10, 20]');
+    assert.equal(formatKeyframeValue('{"x":1,"y":2,"z":3}'), '[1, 2, 3]');
+  });
+
+  it('accepts real {x,y,z} objects', () => {
+    assert.equal(formatKeyframeValue({ x: 10, y: 20 }), '[10, 20]');
+    assert.equal(formatKeyframeValue({ x: 1, y: 2, z: 3 }), '[1, 2, 3]');
+  });
+
+  it('keeps genuine non-JSON strings quoted', () => {
+    assert.equal(formatKeyframeValue('hello'), '"hello"');
+    assert.equal(formatKeyframeValue('[not json]'), '"[not json]"');
+    assert.equal(formatKeyframeValue('opacity'), '"opacity"');
+  });
+
+  it('does not recover nested arrays that fail the numeric gate', () => {
+    // Nested arrays are not valid AE multi-dim keyframe values via this path;
+    // they remain quoted strings so AE fails loudly rather than emitting junk.
+    assert.equal(formatKeyframeValue('[[1,2],[3,4]]'), '"[[1,2],[3,4]]"');
+  });
+});

--- a/src/ae-integration/generators/helpers.ts
+++ b/src/ae-integration/generators/helpers.ts
@@ -292,12 +292,38 @@ export function generateForLoop(
 /**
  * Validate that a value can be used as a keyframe value
  */
-export function formatKeyframeValue(value: number | number[] | string): string {
+export function formatKeyframeValue(
+  value: number | number[] | string | { x: number; y: number; z?: number }
+): string {
+  // Defensive: some MCP bridges stringify values whose schema declares no type,
+  // so "[780,780]" or "780" can arrive as strings. Recover the real value.
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    const looksLikeArray = /^\[[\s\d.,eE+-]*\]$/.test(trimmed);
+    const looksLikeNumber = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(trimmed);
+    const looksLikeObject = /^\{[\s\S]*\}$/.test(trimmed);
+    if (looksLikeArray || looksLikeNumber || looksLikeObject) {
+      try {
+        value = JSON.parse(trimmed);
+      } catch (e) {
+        // keep as string
+      }
+    }
+  }
   if (typeof value === 'number') {
     return String(value);
-  } else if (Array.isArray(value)) {
+  }
+  if (Array.isArray(value)) {
     return arrayToES3(value);
-  } else if (typeof value === 'string') {
+  }
+  if (value !== null && typeof value === 'object') {
+    const v = value as { x?: unknown; y?: unknown; z?: unknown };
+    if (typeof v.x === 'number' && typeof v.y === 'number') {
+      return positionToES3(value as { x: number; y: number; z?: number });
+    }
+    throw new Error('Invalid keyframe value: object must have numeric x and y');
+  }
+  if (typeof value === 'string') {
     return '"' + escapeString(value) + '"';
   }
   throw new Error('Invalid keyframe value type');

--- a/src/ae-integration/generators/helpers.ts
+++ b/src/ae-integration/generators/helpers.ts
@@ -295,8 +295,8 @@ export function generateForLoop(
 export function formatKeyframeValue(
   value: number | number[] | string | { x: number; y: number; z?: number }
 ): string {
-  // Defensive: some MCP bridges stringify values whose schema declares no type,
-  // so "[780,780]" or "780" can arrive as strings. Recover the real value.
+  // Defensive: some MCP bridges still stringify values even when the schema
+  // declares a type, so "[780,780]" or "780" can arrive as strings. Recover them.
   if (typeof value === 'string') {
     const trimmed = value.trim();
     const looksLikeArray = /^\[[\s\d.,eE+-]*\]$/.test(trimmed);

--- a/src/ae-integration/scriptGenerator.ts
+++ b/src/ae-integration/scriptGenerator.ts
@@ -23,7 +23,9 @@ export {
   generateDeleteComposition,
   generateListCompositions,
   generateGetCompositionInfo,
-  generateSetActiveComposition
+  generateSetActiveComposition,
+  generateRenderFrame,
+  generateGetCompReport
 } from './generators/compositionGenerators.js';
 
 // Layer generators

--- a/src/stdio-server.ts
+++ b/src/stdio-server.ts
@@ -196,6 +196,36 @@ const TOOLS = [
     },
     generator: generators.generateGetCompositionInfo
   },
+  {
+    name: 'render_frame',
+    description: 'Render a single frame of a composition to a PNG file on disk. Returns the file path so the AI can inspect what the comp actually looks like.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        compId: { type: 'number', description: 'Composition ID' },
+        compName: { type: 'string', description: 'Composition name' },
+        time: { type: 'number', description: 'Time in seconds of the frame to render' },
+        outputDir: { type: 'string', description: 'Output folder (default: ~/Desktop/ae_probe)' },
+        fileName: { type: 'string', description: 'Output file name (default: <comp>_t<time>s.png)' }
+      },
+      required: ['time']
+    },
+    generator: generators.generateRenderFrame
+  },
+  {
+    name: 'get_comp_report',
+    description: 'Full composition report: every layer with geometry, text data, fonts (used vs installed), expressions, keyframes, and animated values sampled over time (at markers by default). Use it to verify the real state of a comp.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        compId: { type: 'number', description: 'Composition ID' },
+        compName: { type: 'string', description: 'Composition name' },
+        sampleTimes: { type: 'array', items: { type: 'number' }, description: 'Times in seconds to sample animated values (default: comp markers, else 5 uniform points)' },
+        textPreview: { type: 'number', description: 'Max characters of text per layer (default 120)' }
+      }
+    },
+    generator: generators.generateGetCompReport
+  },
 
   // ============================================
   // LAYER TOOLS
@@ -465,7 +495,14 @@ const TOOLS = [
         layerName: { type: 'string' },
         property: { type: 'string', description: 'Property name (e.g., "position", "scale", "opacity")' },
         time: { type: 'number', description: 'Time in seconds' },
-        value: { description: 'Property value (number, array, or string)' }
+        value: {
+          oneOf: [
+            { type: 'number' },
+            { type: 'array', items: { type: 'number' } },
+            { type: 'string' }
+          ],
+          description: 'Property value: number, array of numbers (e.g. [540, 960]), or string'
+        }
       },
       required: ['property', 'time', 'value']
     },
@@ -483,7 +520,14 @@ const TOOLS = [
         layerName: { type: 'string' },
         property: { type: 'string' },
         time: { type: 'number' },
-        value: {},
+        value: {
+          oneOf: [
+            { type: 'number' },
+            { type: 'array', items: { type: 'number' } },
+            { type: 'string' }
+          ],
+          description: 'Property value: number, array of numbers, or string'
+        },
         inType: { type: 'string', enum: ['LINEAR', 'BEZIER', 'HOLD'] },
         outType: { type: 'string', enum: ['LINEAR', 'BEZIER', 'HOLD'] },
         inEase: { type: 'object', properties: { speed: { type: 'number' }, influence: { type: 'number' } } },

--- a/src/stdio-server.ts
+++ b/src/stdio-server.ts
@@ -499,9 +499,18 @@ const TOOLS = [
           oneOf: [
             { type: 'number' },
             { type: 'array', items: { type: 'number' } },
-            { type: 'string' }
+            { type: 'string' },
+            {
+              type: 'object',
+              properties: {
+                x: { type: 'number' },
+                y: { type: 'number' },
+                z: { type: 'number' }
+              },
+              required: ['x', 'y']
+            }
           ],
-          description: 'Property value: number, array of numbers (e.g. [540, 960]), or string'
+          description: 'Property value: number, array of numbers (e.g. [540, 960]), {x,y,z?} object, or string'
         }
       },
       required: ['property', 'time', 'value']
@@ -524,9 +533,18 @@ const TOOLS = [
           oneOf: [
             { type: 'number' },
             { type: 'array', items: { type: 'number' } },
-            { type: 'string' }
+            { type: 'string' },
+            {
+              type: 'object',
+              properties: {
+                x: { type: 'number' },
+                y: { type: 'number' },
+                z: { type: 'number' }
+              },
+              required: ['x', 'y']
+            }
           ],
-          description: 'Property value: number, array of numbers, or string'
+          description: 'Property value: number, array of numbers, {x,y,z?} object, or string'
         },
         inType: { type: 'string', enum: ['LINEAR', 'BEZIER', 'HOLD'] },
         outType: { type: 'string', enum: ['LINEAR', 'BEZIER', 'HOLD'] },


### PR DESCRIPTION
## Summary

Two bug fixes that currently break core workflows, plus two new tools that let an AI assistant visually verify what it builds.

## Fixes

**1. `set_keyframe` / `set_keyframe_advanced` rejected array values**

Animating position or scale was impossible: AE returned `Unable to call "setValueAtKey" because of parameter 2. Value is not an array.`

Root cause: the tools' `inputSchema` declared `value` with no type, so some MCP clients/bridges serialize the array to a string (`"[540,960]"`). The zod union then matches `z.string()` and `formatKeyframeValue` quotes it, so ExtendScript receives a string where an array is required.

Fix (both layers, defensively):
- `inputSchema` now declares `oneOf: [number, number[], string]` so well-behaved clients pass arrays natively.
- `formatKeyframeValue` re-parses strings that look like JSON arrays/numbers/objects, and accepts `{x, y, z?}` objects, so stringifying bridges still work.

**2. `get_expression` always crashed with `SyntaxError: Expected: ;`**

The generator emitted a bare object literal as a statement:

```js
{
  property: "...",
  expression: prop.expression
};
```

ExtendScript parses a `{` at statement position as a *block* (making `property:` a label), which throws. The generator now assigns to a variable and returns it, matching every other generator in the codebase.

## New tools

**`render_frame {compName?, compId?, time, outputDir?, fileName?}`**
Saves a single comp frame to PNG (via `CompItem.saveFrameToPng`) and returns the file path. This closes the feedback loop for AI-driven work: the assistant can look at the frame it just produced instead of building blind.

**`get_comp_report {compName?, compId?, sampleTimes?, textPreview?}`**
One-call JSON report of a comp's real state: every layer with geometry (`sourceRectAtTime`), transform, parent and 3D rotations; text layers with font, size and a content preview; fonts used vs. installed; every expression and keyframe (recursive walk); and animated values sampled over time: at the comp markers by default. Lets the assistant verify its writes instead of trusting them.

## Notes

- All generated code remains strict ES3, consistent with the project's conventions.
- `saveFrameToPng` is undocumented Adobe API, stable since CC 2020; `render_frame` throws a clear error if it's unavailable.
- Tested live on AE 2024 / macOS through the CEP panel: array keyframes on position/scale, expression read-back round-trip, ~15 frame renders, and full reports on an 11-layer comp with camera, 3D text and expressions.
